### PR TITLE
Escape channel names the same way as ZNC Log module does it

### DIFF
--- a/backlog.cpp
+++ b/backlog.cpp
@@ -102,7 +102,7 @@ void CBacklogMod::OnModCommand(const CString& sCommand) {
 
     CString Path = GetNV("LogPath").substr(); // make copy
     Path.Replace("$NETWORK", Network);
-    Path.Replace("$WINDOW", Channel.AsLower());
+    Path.Replace("$WINDOW", CString(Channel.Replace_n("/", "-").Replace_n("\\", "-")).AsLower());
     Path.Replace("$USER", User);
 
     CString DirPath = Path.substr(0, Path.find_last_of("/"));


### PR DESCRIPTION
This should fix issue #2 

Better late than never, right? :'D